### PR TITLE
Fix SettingsViewController instance method return type for Swift

### DIFF
--- a/include/ABLLinkSettingsViewController.h
+++ b/include/ABLLinkSettingsViewController.h
@@ -20,6 +20,6 @@
     controller given an ABLLink instance. Clients must ensure that the
     ABLLink instance is not destroyed before the view controller.
 */
-+ (id)instance:(ABLLinkRef)ablLink;
++ (instancetype)instance:(ABLLinkRef)ablLink;
 
 @end


### PR DESCRIPTION
Change factory method return type to `instancetype`.
Using `instancetype` return type instead of `id` is the cocoa way for creating init methods.
It automatically returns the type of initializing class. So, it is more Swift friendly.