### PR TITLE
Add ABLLinkSetNumPeersCallback

### DIFF
--- a/LinkKit/ABLLink.h
+++ b/LinkKit/ABLLink.h
@@ -81,6 +81,17 @@ extern "C"
    */
   bool ABLLinkIsStartStopSyncEnabled(ABLLinkRef);
 
+  /*! @brief Called if number of peers changes.
+   *
+   *  @param numPeers New amount of peers
+   *
+   *  @discussion This is a stable value that is appropriate for display
+   *  to the user.
+   */
+  typedef void (*ABLLinkNumPeersCallback)(
+    int numPeers,
+    void *context);
+
   /*! @brief Called if Session Tempo changes.
    *
    *  @param sessionTempo New session tempo in bpm
@@ -124,6 +135,13 @@ extern "C"
   typedef void (*ABLLinkIsConnectedCallback)(
     bool isConnected,
     void *context);
+
+  /*! @brief Called when the amount of peers changes.
+   */
+  void ABLLinkSetNumPeersCallback(
+    ABLLinkRef,
+    ABLLinkNumPeersCallback callback,
+    void* context);
 
   /*! @brief Invoked on the main thread when the tempo of the Link
    *  session changes.

--- a/LinkKit/ABLLink.mm
+++ b/LinkKit/ABLLink.mm
@@ -140,6 +140,27 @@ extern "C"
     return ablLink->mLink.isEnabled() && ablLink->mLink.numPeers() > 0;
   }
 
+  void ABLLinkSetNumPeersCallback(
+    ABLLinkRef ablLink,
+    ABLLinkNumPeersCallback callback,
+    void* context)
+  {
+    ablLink->mpCallbacks->mPeerCountCallback = [=](const std::size_t peers){
+      
+      if(ablLink->mLink.isEnabled()){
+        const size_t oldNumPeers = ablLink->mpSettingsViewController.numberOfPeers;
+        if (oldNumPeers == 0 && peers > 0) {
+          ablLink->mpCallbacks->mIsConnectedCallback(true);
+        }else if (oldNumPeers > 0 && peers == 0) {
+          ablLink->mpCallbacks->mIsConnectedCallback(false);
+        }
+        callback(int(peers), context);
+        [ablLink->mpSettingsViewController setNumberOfPeers:peers];
+      }
+    
+    };
+  }
+
   void ABLLinkSetSessionTempoCallback(
     ABLLinkRef ablLink,
     ABLLinkSessionTempoCallback callback,


### PR DESCRIPTION
This addition will introduce a new method ABLLinkSetNumPeersCallback(), which is a bridge to the Link C API callback function setNumPeersCallback(). It will keep the functionality introduced in ABLLinkNew(), meaning it will also keep notifying IsConnectedCallback() and update SettingsViewController but not call the Notification View.

The intend of having this method is to offer the possibility to draw notifications independently from Ableton LinkKit in case the applications UIWindow can not be accessed because the library is hosted inside an extension or JUCE as discussed here: https://github.com/Ableton/LinkKit/issues/45